### PR TITLE
adds boto3 version of killer.py script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.ropeproject/

--- a/README.md
+++ b/README.md
@@ -4,7 +4,11 @@ Bash and Python script to kill Amazon EC2 instances based on elapsed time since 
 
 ***TERMINATE EXECUTABLE NEEDS TO BE UNCOMMENTED IN THE SCRIPTS***
 
-## Python
+## Python + boto3
+
+The script `killer3.py` is a boto3-based version of the killer.py script. The boto3 version adds the ability to specify an AWS CLI profile to use for authentication. Also the script requires that you specify the `-y` or `--yes` argument to terminate instances. Otherwise it does not make any changes. Like the previous script, the actual line to terminate the instance is commented out. This is a dangerous script! Use wisely and at your own risk.
+
+## Python + boto2
 
 Requirements:
 
@@ -49,4 +53,3 @@ eg
 `./killer.sh 72 48`
 
 Amazon CLI environment variables must be set as normal for use with Amazon CLI
-

--- a/killer3.py
+++ b/killer3.py
@@ -1,20 +1,22 @@
-# killer3.py - boto3-based version of the killer.py script.
+#!/usr/bin/env python2
+# killer3.py - terminate long running EC2 instances
 
-# Add the ability to specify which AWS CLI profile you want to use. You must
-# specify the '-y' option to actually terminate instances.
+"""killer3.py
 
-import argparse
+Terminates long running EC2 instances. The number of hours an instance must be
+up before being terminated can be defined on the command line. The user must
+explicitly pass the '-y' or '--yes' option before instances will be terminated.
+Otherwise the script does not make any changes.
+"""
 
-from boto3 import session, ec2
 from datetime import tzinfo, timedelta, datetime
-from pprint import PrettyPrinter
 
 ZERO = timedelta(0)
 HOUR = timedelta(hours=1)
 
 # A UTC class.
 class UTC(tzinfo):
-    """UTC"""
+    """Creates a UTC instance of the tzinfo class"""
 
     def utcoffset(self, dt):
         return ZERO
@@ -25,38 +27,62 @@ class UTC(tzinfo):
     def dst(self, dt):
         return ZERO
 
-utc = UTC()
 
-pp = PrettyPrinter(indent=4)
+def get_args():
+    """Processes command line arguments"""
+    import argparse
 
-parser = argparse.ArgumentParser()
-parser.add_argument("-t", "--terminate", type=int, help="Terminate instances older than this many hours", default=72)
-parser.add_argument("-w", "--warn", type=int, help="Warn about any instances older than this many hours", default=36)
-parser.add_argument("-p", "--profile", help="The awscli profile name you wish to use", default="default")
-parser.add_argument("-r", "--region", help="The AWS region you want to interact with", default="us-east-1")
-parser.add_argument("-y", "--yes", help="Terminate all instances older than the specified termination time", action="store_true")
-args = parser.parse_args()
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-t", "--terminate", type=int,
+                        help="Terminate instances older than this many hours (default 72)",
+                        default=72)
+    parser.add_argument("-w", "--warn", type=int,
+                        help="Warn for any instances older than this many hours (default 36)",
+                        default=36)
+    parser.add_argument("-p", "--profile",
+                        help="The awscli profile name you wish to use (default 'default')",
+                        default="default")
+    parser.add_argument("-r", "--region",
+                        help="The AWS region you want to interact with (default us-east-1)",
+                        default="us-east-1")
+    parser.add_argument("-y", "--yes",
+                        help="Terminate instances (default is 'do nothing')",
+                        action="store_true")
+    return(parser.parse_args())
 
-now = datetime.now(utc)
-delta_kill = now - timedelta(hours=args.terminate)
-delta_warn = now - timedelta(hours=args.warn)
 
-session = session.Session(region_name=args.region, profile_name=args.profile)
-ec2 = session.client('ec2')
-response = ec2.describe_instances()
+def main():
 
-warn_instances = []
-for reservation in response[u'Reservations']:
-    for instance in reservation[u'Instances']:
-        launchtime = instance[u'LaunchTime']
-        if launchtime < delta_kill and args.yes:
-            print "Terminating instance", instance[u'InstanceId']
-            #ec2.terminate_instances(InstanceIds=[instance[u'InstanceId']])
-        elif launchtime < delta_kill and not args.yes:
-            print "Skipping instance", instance[u'InstanceId']
-        elif launchtime < delta_warn:
-            warn_instances += instance
+    from boto3 import session, ec2
+    from pprint import PrettyPrinter
 
-if warn_instances:
-    print "The following instances are more than ", args.warn, "hrs old."
-    pp.pprint(warn_instances)
+    utc = UTC()
+    pp = PrettyPrinter(indent=4)
+    args = get_args()
+
+    delta_kill = datetime.now(utc) - timedelta(hours=args.terminate)
+    delta_warn = datetime.now(utc) - timedelta(hours=args.warn)
+
+    session = session.Session(region_name=args.region, profile_name=args.profile)
+    ec2 = session.client('ec2')
+    response = ec2.describe_instances()
+
+    warn_instances = []
+    for reservation in response[u'Reservations']:
+        for instance in reservation[u'Instances']:
+            launchtime = instance[u'LaunchTime']
+            if launchtime < delta_kill and args.yes:
+                print "Terminating instance", instance[u'InstanceId']
+                #ec2.terminate_instances(InstanceIds=[instance[u'InstanceId']])
+            elif launchtime < delta_kill and not args.yes:
+                print "Skipping instance", instance[u'InstanceId']
+            elif launchtime < delta_warn:
+                warn_instances += instance
+
+    if warn_instances:
+        print "The following instances are more than ", args.warn, "hrs old."
+        pp.pprint(warn_instances)
+
+
+if __name__ == '__main__':
+    main()

--- a/killer3.py
+++ b/killer3.py
@@ -1,0 +1,62 @@
+# killer3.py - boto3-based version of the killer.py script.
+
+# Add the ability to specify which AWS CLI profile you want to use. You must
+# specify the '-y' option to actually terminate instances.
+
+import argparse
+
+from boto3 import session, ec2
+from datetime import tzinfo, timedelta, datetime
+from pprint import PrettyPrinter
+
+ZERO = timedelta(0)
+HOUR = timedelta(hours=1)
+
+# A UTC class.
+class UTC(tzinfo):
+    """UTC"""
+
+    def utcoffset(self, dt):
+        return ZERO
+
+    def tzname(self, dt):
+        return "UTC"
+
+    def dst(self, dt):
+        return ZERO
+
+utc = UTC()
+
+pp = PrettyPrinter(indent=4)
+
+parser = argparse.ArgumentParser()
+parser.add_argument("-t", "--terminate", type=int, help="Terminate instances older than this many hours", default=72)
+parser.add_argument("-w", "--warn", type=int, help="Warn about any instances older than this many hours", default=36)
+parser.add_argument("-p", "--profile", help="The awscli profile name you wish to use", default="default")
+parser.add_argument("-r", "--region", help="The AWS region you want to interact with", default="us-east-1")
+parser.add_argument("-y", "--yes", help="Terminate all instances older than the specified termination time", action="store_true")
+args = parser.parse_args()
+
+now = datetime.now(utc)
+delta_kill = now - timedelta(hours=args.terminate)
+delta_warn = now - timedelta(hours=args.warn)
+
+session = session.Session(region_name=args.region, profile_name=args.profile)
+ec2 = session.client('ec2')
+response = ec2.describe_instances()
+
+warn_instances = []
+for reservation in response[u'Reservations']:
+    for instance in reservation[u'Instances']:
+        launchtime = instance[u'LaunchTime']
+        if launchtime < delta_kill and args.yes:
+            print "Terminating instance", instance[u'InstanceId']
+            #ec2.terminate_instances(InstanceIds=[instance[u'InstanceId']])
+        elif launchtime < delta_kill and not args.yes:
+            print "Skipping instance", instance[u'InstanceId']
+        elif launchtime < delta_warn:
+            warn_instances += instance
+
+if warn_instances:
+    print "The following instances are more than ", args.warn, "hrs old."
+    pp.pprint(warn_instances)

--- a/killer3.py.bak
+++ b/killer3.py.bak
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python2
 # killer3.py - terminate long running EC2 instances
 
 """killer3.py
@@ -68,19 +68,19 @@ def main():
     response = ec2.describe_instances()
 
     warn_instances = []
-    for reservation in response['Reservations']:
-        for instance in reservation['Instances']:
-            launchtime = instance['LaunchTime']
+    for reservation in response[u'Reservations']:
+        for instance in reservation[u'Instances']:
+            launchtime = instance[u'LaunchTime']
             if launchtime < delta_kill and args.yes:
-                print("Terminating instance", instance['InstanceId'])
+                print "Terminating instance", instance[u'InstanceId']
                 #ec2.terminate_instances(InstanceIds=[instance[u'InstanceId']])
             elif launchtime < delta_kill and not args.yes:
-                print("Skipping instance", instance['InstanceId'])
+                print "Skipping instance", instance[u'InstanceId']
             elif launchtime < delta_warn:
                 warn_instances += instance
 
     if warn_instances:
-        print("The following instances are more than ", args.warn, "hrs old.")
+        print "The following instances are more than ", args.warn, "hrs old."
         pp.pprint(warn_instances)
 
 


### PR DESCRIPTION
Adds a boto3-based script for killing long-running EC2 instances. Include ability to specify an AWS CLI profile for authentication. Does nothing by default. User must explicitly pass `-y` or `--yes` argument to trigger instance termination.